### PR TITLE
Path fixes #2

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -8,8 +8,9 @@ mkdir -p \
 [[ ! -f "/config/data/config.php" ]] && \
 	cp /app/grocy/config-dist.php /config/data/config.php
 
+# check for plugins existence, copy if required
 [[ ! -f "/config/data/plugins/DemoBarcodeLookupPlugin.php" ]] && \
-	cp -R /defaults/plugins /config/data
+	cp -R /defaults/plugins/ /config/data
 
 # create symlinks
 symlinks=( \

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -1,8 +1,13 @@
 #!/usr/bin/with-contenv bash
 
-# create directory structure
-mkdir -p \
-    /config/data/{plugins,viewcache}
+# create symlinks
+i=/app/grocy/data
+[[ -e "$i" && ! -L "$i" && -e /config/"$(basename "$i")" ]] && \
+        rm -Rf "$i" && \
+        ln -s /config/"$(basename "$i")" "$i"
+[[ -e "$i" && ! -L "$i" ]] && \
+	mv "$i" /config/"$(basename "$i")" && \
+	ln -s /config/"$(basename "$i")" "$i"
 
 # check for config file and copy default if needed
 [[ ! -f "/config/data/config.php" ]] && \
@@ -10,12 +15,6 @@ mkdir -p \
 
 [[ ! -f "/config/data/plugins/DemoBarcodeLookupPlugin.php" ]] && \
     cp -R /defaults/plugins /config/data
-
-# create symlinks
-i=/app/grocy/data
-[[ -e "$i" && ! -L "$i" ]] && \
-rm -rf "$i" && \
-ln -s /config/"$(basename "$i")" "$i"
 
 chown -R abc:abc \
     /app/grocy \

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -2,29 +2,21 @@
 
 # create directory structure
 mkdir -p \
-	/config/data/{plugins,viewcache}
+    /config/data/{plugins,viewcache}
 
 # check for config file and copy default if needed
 [[ ! -f "/config/data/config.php" ]] && \
-	cp /app/grocy/config-dist.php /config/data/config.php
+    cp /app/grocy/config-dist.php /config/data/config.php
 
-# check for plugins existence, copy if required
 [[ ! -f "/config/data/plugins/DemoBarcodeLookupPlugin.php" ]] && \
-	cp -R /defaults/plugins/ /config/data
+    cp -R /defaults/plugins /config/data
 
 # create symlinks
-symlinks=( \
-/app/grocy/data/plugins \
-/app/grocy/data/viewcache \
-/app/grocy/data 
-)
-
-for i in "${symlinks[@]}"
-do
-[[ -e "$i" && ! -L "$i" ]] && rm -rf "$i"
-[[ ! -L "$i" ]] && ln -s /config/"$(basename "$i")" "$i"
-done
+i=/app/grocy/data
+[[ -e "$i" && ! -L "$i" ]] && \
+rm -rf "$i" && \
+ln -s /config/"$(basename "$i")" "$i"
 
 chown -R abc:abc \
-	/app/grocy \
-	/config
+    /app/grocy \
+    /config


### PR DESCRIPTION
Fixes for the initial init , the symlink check first sees if this is a container upgrade by checking for the existence of the data dir in /config, if present we purge the in container one and symlink it out. 
If not present we move the data dir and symlink it out. 

Copying of the base files occurs after the data symlink has been made. 

https://github.com/linuxserver/docker-grocy/issues/2