### PR TITLE
Add gd php extension required as of v2.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN \
  apk add --no-cache \
 	curl \
 	php7 \
+	php7-gd \
 	php7-pdo \
 	php7-pdo_sqlite \
 	php7-tokenizer && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -17,6 +17,7 @@ RUN \
  apk add --no-cache \
 	curl \
 	php7 \
+	php7-gd \
 	php7-pdo \
 	php7-pdo_sqlite \
 	php7-tokenizer && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -17,6 +17,7 @@ RUN \
  apk add --no-cache \
 	curl \
 	php7 \
+	php7-gd \
 	php7-pdo \
 	php7-pdo_sqlite \
 	php7-tokenizer && \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -39,6 +39,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "22.09.19:", desc: "Add 'gd' PHP extension." }
   - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "22.02.19:", desc: "Rebasing to alpine 3.9." }


### PR DESCRIPTION
New package "gumlet/php-image-resize" was added and requires gd php extensions.

Added `php7-gd` to `apk add` in each Dockerfile.