### PR TITLE
Manually change Grocys required PHP version to 7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG GROCY_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="alex-phillips, homerr"
 
+##FIXME: Once PHP 7.4 is integrated, remove the sed statements for composer!
 RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
@@ -37,6 +38,8 @@ RUN \
  cp -R /app/grocy/data/plugins \
 	/defaults/plugins && \
  echo "**** install composer packages ****" && \
+ sed -i 's/[[:blank:]]*"php": ">=7.4",/"php": ">=7.3",/g' /app/grocy/composer.json && \
+ sed -i 's/[[:blank:]]*"php": ">=7.4"/"php": ">=7.3"/g' /app/grocy/composer.lock && \
  composer install -d /app/grocy --no-dev && \
  echo "**** install yarn packages ****" && \
  cd /app/grocy && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -7,6 +7,7 @@ ARG GROCY_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="alex-phillips, homerr"
 
+##FIXME: Once PHP 7.4 is integrated, remove the sed statements for composer!
 RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
@@ -37,6 +38,8 @@ RUN \
  cp -R /app/grocy/data/plugins \
 	/defaults/plugins && \
  echo "**** install composer packages ****" && \
+ sed -i 's/[[:blank:]]*"php": ">=7.4",/"php": ">=7.3",/g' /app/grocy/composer.json && \
+ sed -i 's/[[:blank:]]*"php": ">=7.4"/"php": ">=7.3"/g' /app/grocy/composer.lock && \
  composer install -d /app/grocy --no-dev && \
  echo "**** install yarn packages ****" && \
  cd /app/grocy && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -7,6 +7,7 @@ ARG GROCY_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="alex-phillips, homerr"
 
+##FIXME: Once PHP 7.4 is integrated, remove the sed statements for composer!
 RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
@@ -37,6 +38,8 @@ RUN \
  cp -R /app/grocy/data/plugins \
 	/defaults/plugins && \
  echo "**** install composer packages ****" && \
+ sed -i 's/[[:blank:]]*"php": ">=7.4",/"php": ">=7.3",/g' /app/grocy/composer.json && \
+ sed -i 's/[[:blank:]]*"php": ">=7.4"/"php": ">=7.3"/g' /app/grocy/composer.lock && \
  composer install -d /app/grocy --no-dev && \
  echo "**** install yarn packages ****" && \
  cd /app/grocy && \


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [ x] I have read the [contributing](https://github.com/linuxserver/docker-grocy/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
Very dirty hotfix so that the image can successfully be built

As PHP 7.4 is not strictly required for Grocy (only set as it is only tested with 7.4) it is safe to manually reduce the version to 7.3 _for now_. This is not supposed to be a permanent change and should be removed as soon as PHP 7.4 is included in this image.

## Benefits of this PR and context:
Version 3.0.1 is supported

## How Has This Been Tested?
Building image, PHP 7.3 works fine on my local machine

## Source / References:
Issue #30 