### PR TITLE
Added dependencies for Grocy and hotfix for PHP<8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG GROCY_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="alex-phillips, homerr"
 
+##FIXME: Once PHP8 is integrated, remove the sed statements for composer!
 RUN \
   echo "**** install build packages ****" && \
   apk add --no-cache --virtual=build-dependencies \
@@ -18,11 +19,14 @@ RUN \
     curl \
     php7 \
     php7-ctype \
+    php7-intl \
     php7-ldap \
     php7-gd \
+    php7-json \
     php7-pdo \
     php7-pdo_sqlite \
-    php7-tokenizer && \
+    php7-tokenizer \
+    php7-zlib && \
   echo "**** install grocy ****" && \
   mkdir -p /app/grocy && \
   if [ -z ${GROCY_RELEASE+x} ]; then \
@@ -38,6 +42,8 @@ RUN \
   cp -R /app/grocy/data/plugins \
     /defaults/plugins && \
   echo "**** install composer packages ****" && \
+ sed -i 's/[[:blank:]]*"php": ">=8.0",/"php": ">=7.4",/g' /app/grocy/composer.json && \
+ sed -i 's/[[:blank:]]*"php": ">=8.0"/"php": ">=7.4"/g' /app/grocy/composer.lock && \
   composer install -d /app/grocy --no-dev && \
   echo "**** install yarn packages ****" && \
   cd /app/grocy && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -7,6 +7,7 @@ ARG GROCY_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="alex-phillips, homerr"
 
+##FIXME: Once PHP8 is integrated, remove the sed statements for composer!
 RUN \
   echo "**** install build packages ****" && \
   apk add --no-cache --virtual=build-dependencies \
@@ -18,11 +19,14 @@ RUN \
     curl \
     php7 \
     php7-ctype \
+    php7-intl \
     php7-ldap \
     php7-gd \
+    php7-json \
     php7-pdo \
     php7-pdo_sqlite \
-    php7-tokenizer && \
+    php7-tokenizer \
+    php7-zlib && \
   echo "**** install grocy ****" && \
   mkdir -p /app/grocy && \
   if [ -z ${GROCY_RELEASE+x} ]; then \
@@ -38,6 +42,8 @@ RUN \
   cp -R /app/grocy/data/plugins \
     /defaults/plugins && \
   echo "**** install composer packages ****" && \
+ sed -i 's/[[:blank:]]*"php": ">=8.0",/"php": ">=7.4",/g' /app/grocy/composer.json && \
+ sed -i 's/[[:blank:]]*"php": ">=8.0"/"php": ">=7.4"/g' /app/grocy/composer.lock && \
   composer install -d /app/grocy --no-dev && \
   echo "**** install yarn packages ****" && \
   cd /app/grocy && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -7,6 +7,7 @@ ARG GROCY_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="alex-phillips, homerr"
 
+##FIXME: Once PHP8 is integrated, remove the sed statements for composer!
 RUN \
   echo "**** install build packages ****" && \
   apk add --no-cache --virtual=build-dependencies \
@@ -18,11 +19,14 @@ RUN \
     curl \
     php7 \
     php7-ctype \
+    php7-intl \
     php7-ldap \
     php7-gd \
+    php7-json \
     php7-pdo \
     php7-pdo_sqlite \
-    php7-tokenizer && \
+    php7-tokenizer \
+    php7-zlib && \
   echo "**** install grocy ****" && \
   mkdir -p /app/grocy && \
   if [ -z ${GROCY_RELEASE+x} ]; then \
@@ -38,6 +42,8 @@ RUN \
   cp -R /app/grocy/data/plugins \
     /defaults/plugins && \
   echo "**** install composer packages ****" && \
+ sed -i 's/[[:blank:]]*"php": ">=8.0",/"php": ">=7.4",/g' /app/grocy/composer.json && \
+ sed -i 's/[[:blank:]]*"php": ">=8.0"/"php": ">=7.4"/g' /app/grocy/composer.lock && \
   composer install -d /app/grocy --no-dev && \
   echo "**** install yarn packages ****" && \
   cd /app/grocy && \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -39,6 +39,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "25.07.21:", desc: "Add 'int','json' and 'zlib' PHP extensions." }
   - { date: "10.05.21:", desc: "Reduce image size." }
   - { date: "08.04.21:", desc: "Update docs to reflect jenkins builder changes." }
   - { date: "17.02.21:", desc: "Rebasing to alpine 3.13." }


### PR DESCRIPTION

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-grocy/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
This Pullrequest includes two changes:

- Adding the dependencies intl, json and zlib
- Adding a hotfix to reduce minimum PHP version required by composer to 7.4, as the Grocy author unknowingly set it to 8.0 

As soon as the author fixes the problem or this image is updated to PHP 8.0, the `sed` statements should be removed!

## Benefits of this PR and context:
The build succeeds

## How Has This Been Tested?
Building and login to application was sucessful.


## Source / References:
Problem is acknowledged in https://github.com/grocy/grocy/issues/1537
